### PR TITLE
PROD-9734 Include CA certificates in docker image.

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,10 @@
 FROM progrium/busybox
 MAINTAINER mstemm@jut.io
 
+# Grab the CA certificates list. This should have been copied into the
+# current directory by build.sh.
+ADD ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 # Grab jut-cadvisor-agent from the staging directory.
 ADD jut-cadvisor-agent /usr/bin/jut-cadvisor-agent
 

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -7,4 +7,9 @@ set -x
 
 godep go build -a github.com/jut-io/jut-cadvisor-agent
 
+# jut-cadvisor-agent is looking for a file called ca-certificates.crt,
+# hence the rename. The Dockerfile will additionally copy it into an
+# appropriate location for the go program.
+cp /etc/ssl/certs/ca-bundle.crt ./ca-certificates.crt
+
 sudo docker build -t jutd/jut-cadvisor-agent:latest .


### PR DESCRIPTION
Modify the build.sh script to copy the ssl certificates list from
/etc/ssl/certs to the current directory. This is needed as the ADD
command only uses absolute paths.

Modify the Dockerfile to copy to /etc/ssl/certs within the image.
