### PR TITLE
PROD-9688 allow for specifying space/data_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The full set of command line arguments is:
 
 `apikey=""` - Jut Data Engine API Key. Must be provided.<br>
 `cadvisor_url=http://127.0.0.1:8080` - cAdvisor Root URL.<br>
+`data_source="docker"` - Data Source to use for points.<br>
 `datanode=""` - Jut Data Node Hostname. Must be provided.<br>
 `poll_interval=30` - How often to poll containers (seconds).<br>
 `allow_insecure_ssl=false` - Allow insecure certificates when connecting to Jut Data Node.<br>
@@ -30,6 +31,7 @@ The full set of command line arguments is:
 `log_backtrace_at=:0:` - when logging hits line file:N, emit a stack trace.<br>
 `log_dir=""` - If non-empty, write log files in this directory.<br>
 `logtostderr=false` - log to standard error instead of files.<br>
+`space="default"` - Jut Space to use for points.<br>
 `stderrthreshold=0` - logs at or above this threshold go to stderr.<br>
 `v=0` - log level for V logs.<br>
 `vmodule` - comma-separated list of pattern=N settings for file-filtered logging.<br>


### PR DESCRIPTION
Fixes PROD-9688. New options --data_source and --space allow
specifying the data source and space. --space is added to the url,
--data_source replaces the hardcoded docker in the url and is added to
all metric/event points.
