### PR TITLE
PROD-9814 (add docker network metrics) and PROD-9898 (Change default …

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -8,13 +8,13 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client",
-			"Comment": "0.16.0.2",
-			"Rev": "cefada41b87c35294533638733c563a349b95f05"
+			"Comment": "0.18.0-19-g8dcf46b",
+			"Rev": "8dcf46b1539958c2b984df08edfa04d21069bb01"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "0.16.0.2",
-			"Rev": "cefada41b87c35294533638733c563a349b95f05"
+			"Comment": "0.18.0-19-g8dcf46b",
+			"Rev": "8dcf46b1539958c2b984df08edfa04d21069bb01"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/google/cadvisor/info/v1/container.go
+++ b/Godeps/_workspace/src/github.com/google/cadvisor/info/v1/container.go
@@ -312,6 +312,8 @@ type MemoryStats struct {
 	// Units: Bytes.
 	WorkingSet uint64 `json:"working_set"`
 
+	Failcnt uint64 `json:"failcnt"`
+
 	ContainerData    MemoryStatsMemoryData `json:"container_data,omitempty"`
 	HierarchicalData MemoryStatsMemoryData `json:"hierarchical_data,omitempty"`
 }
@@ -345,6 +347,35 @@ type InterfaceStats struct {
 type NetworkStats struct {
 	InterfaceStats `json:",inline"`
 	Interfaces     []InterfaceStats `json:"interfaces,omitempty"`
+	// TCP connection stats (Established, Listen...)
+	Tcp TcpStat `json:"tcp"`
+	// TCP6 connection stats (Established, Listen...)
+	Tcp6 TcpStat `json:"tcp6"`
+}
+
+type TcpStat struct {
+	//Count of TCP connections in state "Established"
+	Established uint64
+	//Count of TCP connections in state "Syn_Sent"
+	SynSent uint64
+	//Count of TCP connections in state "Syn_Recv"
+	SynRecv uint64
+	//Count of TCP connections in state "Fin_Wait1"
+	FinWait1 uint64
+	//Count of TCP connections in state "Fin_Wait2"
+	FinWait2 uint64
+	//Count of TCP connections in state "Time_Wait
+	TimeWait uint64
+	//Count of TCP connections in state "Close"
+	Close uint64
+	//Count of TCP connections in state "Close_Wait"
+	CloseWait uint64
+	//Count of TCP connections in state "Listen_Ack"
+	LastAck uint64
+	//Count of TCP connections in state "Listen"
+	Listen uint64
+	//Count of TCP connections in state "Closing"
+	Closing uint64
 }
 
 type FsStats struct {

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ The full set of command line arguments is:
 `cadvisor_url=http://127.0.0.1:8080` - cAdvisor Root URL.<br>
 `data_source="docker"` - Data Source to use for points.<br>
 `datanode=""` - Jut Data Node Hostname. Must be provided.<br>
-`poll_interval=30` - How often to poll containers (seconds).<br>
+`poll_interval=10` - How often to poll containers (seconds).<br>
 `allow_insecure_ssl=false` - Allow insecure certificates when connecting to Jut Data Node.<br>
-`alsologtostderr=false` - log to standard error as well as files.<br>
+`alsologtostderr=true` - log to standard error as well as files.<br>
 `metrics=true` - Collect Metrics from cAdvisor and send to Data Node.<br>
 `events=true` - Collect Events from cAdvisor and send to Data Node.<br>
 `full_metrics=false` - Collect and report full set of metrics from containers.<br>

--- a/jut_cadvisor_agent.go
+++ b/jut_cadvisor_agent.go
@@ -459,6 +459,8 @@ func checkNonEmpty(arg string, argName string) {
 
 func main() {
 
+	flag.Set("alsologtostderr", "true")
+
 	flag.StringVar(&config.Apikey, "apikey", "", "Jut Data Engine API Key")
 	flag.StringVar(&config.CadvisorUrl, "cadvisor_url", "http://127.0.0.1:8080", "cAdvisor Root URL")
 	flag.StringVar(&config.Datanode, "datanode", "", "Jut Data Node Hostname")


### PR DESCRIPTION
…args to jut_cadvisor_agent).

Update to the latest release of google cadvisor when building. This is
only indirectly related to the problem described in PROD-9814 (docker
integration does not capture network traffic metrics), as the true bug
is in cAdvisor itself, and simply upgrading the running version
cadvisor to 0.18.0 allows network metrics to start flowing. But might
as well build against the same version.

To fix PROD-9898, set the flag value for --alsologtostderr to
true, _before_ pasing the command line arguments. That way anything
actually specified on the command line still overrides.
